### PR TITLE
feat: create enabledIn setting #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
           ],
           "markdownDescription": "Specifies which languages should not be checked for line length.\n\n*This setting also disables rulers in these languages.*"
         },
+        "too-long-line-limit.enabledIn": {
+          "type": "array",
+          "default": [],
+          "markdownDescription": "Specifies which languages should be checked for line length.\n\n*This setting override and disable `#too-long-line-limit.disabledIn#` if not empty."
+        },
         "too-long-line-limit.softLimitSeverity": {
           "type": "string",
           "default": "1",

--- a/src/fileValidator.ts
+++ b/src/fileValidator.ts
@@ -22,10 +22,18 @@ export const fileValidator = (
   // Array for diagnostic elements
   let diagArray = new Array<Diagnostic>();
 
-  // If document language is in disabled list, skip validation
-  if (config.disabledIn().includes(e.document.languageId)) {
-    diagCollection.has(e.document.uri) && diagCollection.delete(e.document.uri);
-    return;
+  // If document language is not in enabledIn list, skip validation
+  if (config.enabledIn().length > 0) {
+    if (!config.enabledIn().includes(e.document.languageId)) {
+      return;
+    }
+  } else {
+    // If document language is in disabled list, skip validation
+    if (config.disabledIn().includes(e.document.languageId)) {
+      diagCollection.has(e.document.uri)
+      && diagCollection.delete(e.document.uri);
+      return;
+    }
   }
 
   // Loop through all lines in document

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -57,6 +57,15 @@ const disabledIn = (): string[] => {
   return [];
 };
 
+const enabledIn = (): string[] => {
+  const config = workspace.getConfiguration(exName).get("enabledIn");
+
+  if (config) {
+    return config as Array<string>;
+  }
+  return [];
+};
+
 /**
  * Access to extension configuration
  */
@@ -65,4 +74,5 @@ export const config = {
   severity: severity,
   rulersEnabled: rulersEnabled,
   disabledIn: disabledIn,
+  enabledIn: enabledIn,
 };


### PR DESCRIPTION
close #3 

Context:
A setting `disabledIn` was used to prevent warning on specific language. If the extension is used only on specific languages, it was necessary to write all the rest.

Suggestion:
With a new setting `enabledIn`, the goal is to activate the warnings only on some specific language.